### PR TITLE
draft: DuckDB & Parquet/Avro usages implementation for Metrics Storage

### DIFF
--- a/apm/pom.xml
+++ b/apm/pom.xml
@@ -20,6 +20,11 @@
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.duckdb</groupId>
+            <artifactId>duckdb_jdbc</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
             <version>1.15.0</version>
@@ -30,7 +35,18 @@
             <version>1.12.0</version>
         </dependency>
 
-
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apm/src/main/java/com/allemas/jheap/Drain.java
+++ b/apm/src/main/java/com/allemas/jheap/Drain.java
@@ -22,7 +22,7 @@ public class Drain extends Thread {
                 if (storage.remainingCapacity() < 5) {
                     List<Metric> drainedElements = new ArrayList<>();
                     storage.drain(drainedElements);
-                    MetricWriter.writeToParquetFile(drainedElements, Metric.class);
+                    MetricWriter.writeToParquetFile(drainedElements);
                 }
                 Thread.sleep(Duration.ofSeconds(1));
             } catch (Exception e) {

--- a/apm/src/main/java/com/allemas/jheap/Main.java
+++ b/apm/src/main/java/com/allemas/jheap/Main.java
@@ -8,14 +8,30 @@ import org.apache.parquet.hadoop.ParquetReader;
 
 
 import java.io.IOException;
+import java.sql.SQLException;
 import java.time.Duration;
 
 
 
 public class Main {
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws  SQLException {
         final String INPUT_FILE = "/tmp/jheap-metrics.parquet";
         Path path = new Path(INPUT_FILE);
+        com.allemas.jheap.storage.AvroParquetReader reader = new com.allemas.jheap.storage.AvroParquetReader(":memory:");
+        Metric record = reader.readParquetFile(INPUT_FILE);
+
+        if (record != null) {
+            System.out.println("Read record:");
+            System.out.println("Name: " + record.getName());
+            System.out.println("Source: " + record.getSource());
+            System.out.println("Timestamp: " + record.getTimestamp());
+            System.out.println("Value: " + record.getValue());
+        } else {
+            System.out.println("No record found in the Parquet file.");
+        }
+
+
+        /**
 
         try (ParquetReader<GenericRecord> reader = AvroParquetReader.<GenericRecord>builder(path).build()) {
             GenericRecord record = null;
@@ -31,6 +47,6 @@ public class Main {
         } catch (Exception e) {
             e.printStackTrace();
         }
-
+**/
     }
 }

--- a/apm/src/main/java/com/allemas/jheap/MetricWriter.java
+++ b/apm/src/main/java/com/allemas/jheap/MetricWriter.java
@@ -1,5 +1,6 @@
 package com.allemas.jheap;
 
+import com.allemas.jheap.schema.Metric;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.avro.AvroParquetWriter;
@@ -8,6 +9,7 @@ import org.apache.parquet.hadoop.ParquetWriter;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.sql.SQLException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.util.HadoopOutputFile;
@@ -16,16 +18,22 @@ import org.apache.parquet.io.OutputFile;
 public class MetricWriter {
     private static final String OUTPUT_FILE = "/tmp/jheap-metrics.parquet";
 
-    public static <T extends SpecificRecord> void writeToParquetFile(Iterable<T> records, Class<T> recordClass) throws IOException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+    public static <T extends SpecificRecord> void writeToParquetFile(Iterable<Metric> records) throws IOException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, SQLException {
+        com.allemas.jheap.storage.AvroParquetWriter writer = new com.allemas.jheap.storage.AvroParquetWriter(":memory:");
+
         Path path = new Path(OUTPUT_FILE);
         OutputFile outputFile = HadoopOutputFile.fromPath(path, new Configuration());
-        try (ParquetWriter<T> writer = AvroParquetWriter.<T>builder(outputFile)
-                .withSchema(recordClass.getDeclaredConstructor().newInstance().getSchema())
-                .withWriteMode(ParquetFileWriter.Mode.OVERWRITE).build()
-        ) {
-            for (T record : records) {
-                writer.write(record);
-            }
+        /**   try (ParquetWriter<T> writer = AvroParquetWriter.<T>builder(outputFile)
+         .withSchema(recordClass.getDeclaredConstructor().newInstance().getSchema())
+         .withWriteMode(ParquetFileWriter.Mode.OVERWRITE).build()
+         ) {
+         for (T record : records) {
+         writer.write(record);
+         }
+         }*/
+
+        for (Metric record : records) {
+            writer.writeAvroToParquet(record, path.toString());
         }
     }
 

--- a/apm/src/main/java/com/allemas/jheap/storage/AvroParquetReader.java
+++ b/apm/src/main/java/com/allemas/jheap/storage/AvroParquetReader.java
@@ -1,0 +1,49 @@
+package com.allemas.jheap.storage;
+
+import com.allemas.jheap.schema.Metric;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericData;
+import org.duckdb.DuckDBConnection;
+
+import java.sql.*;
+
+public class AvroParquetReader {
+
+    private final Connection connection;
+
+    public AvroParquetReader(String dbPath) throws SQLException {
+        String url = "jdbc:duckdb:" + dbPath;
+        this.connection = DriverManager.getConnection(url);
+    }
+
+    public Metric readParquetFile(String parquetFilePath) throws SQLException {
+        String sqlCreateTable = "CREATE TABLE IF NOT EXISTS metrics AS SELECT * FROM read_parquet('" + parquetFilePath + "')";
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sqlCreateTable);
+        }
+
+        String query = "SELECT * FROM metrics";
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(query);
+
+        Metric record = null;
+        if (rs.next()) {
+            record = Metric.newBuilder()
+                    .setName(rs.getString("name"))
+                    .setTimestamp(rs.getLong("timestamp"))
+                    .setSource(rs.getString("source"))
+                    .setValue(rs.getFloat("value"))
+                    .setDetails(rs.getString("details"))
+                    .build();
+        }
+
+        return record;
+    }
+
+    public void close() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+}

--- a/apm/src/main/java/com/allemas/jheap/storage/AvroParquetWriter.java
+++ b/apm/src/main/java/com/allemas/jheap/storage/AvroParquetWriter.java
@@ -1,0 +1,55 @@
+package com.allemas.jheap.storage;
+
+
+import com.allemas.jheap.schema.Metric;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.duckdb.DuckDBConnection;
+
+import java.io.IOException;
+import java.sql.*;
+
+public class AvroParquetWriter {
+
+    private final Connection connection;
+
+    public AvroParquetWriter(String dbPath) throws SQLException {
+        String url = "jdbc:duckdb:" + dbPath;
+        this.connection = DriverManager.getConnection(url);
+    }
+
+    public void writeAvroToParquet(Metric record, String outputPath) throws SQLException {
+        String sqlCreateTable = "CREATE TABLE IF NOT EXISTS metrics (" +
+                "name TEXT, " +
+                "source TEXT, " +
+                "timestamp BIGINT, " +
+                "value FLOAT, " +
+                "details TEXT" +
+                ")";
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sqlCreateTable);
+        }
+
+        String sqlInsert = "INSERT INTO metrics (name, source, timestamp, value, details) VALUES (?, ?, ?, ?, ?)";
+        try (PreparedStatement stmt = connection.prepareStatement(sqlInsert)) {
+            stmt.setString(1, record.getName().toString());
+            stmt.setString(2, record.getSource().toString());
+            stmt.setLong(3, (Long) record.getTimestamp());
+            stmt.setObject(4, record.getValue());
+            stmt.setString(5, record.getDetails() != null ? record.getDetails().toString() : null);
+            stmt.executeUpdate();
+        }
+
+        String sqlCopy = "COPY metrics TO '" + outputPath + "' (FORMAT PARQUET)";
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sqlCopy);
+        }
+    }
+
+    public void close() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+}

--- a/apm/src/main/java/com/allemas/jheap/storage/DuckDBStorage.java
+++ b/apm/src/main/java/com/allemas/jheap/storage/DuckDBStorage.java
@@ -1,0 +1,44 @@
+package com.allemas.jheap.storage;
+
+import org.duckdb.DuckDBConnection;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class DuckDBStorage {
+
+    private Connection connection;
+
+    public DuckDBStorage(String dbPath) throws SQLException {
+        String url = "jdbc:duckdb:" + dbPath;
+        this.connection = DriverManager.getConnection(url);
+    }
+
+    public void loadParquetFile(String parquetFilePath) throws SQLException {
+        String sql = "CREATE TABLE IF NOT EXISTS metrics AS SELECT * FROM read_parquet('" + parquetFilePath + "')";
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+
+    public void queryParquetFile(String query) throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.executeQuery(query);
+        }
+    }
+
+    public void writeParquet(String outputPath) throws SQLException {
+        String sql = "COPY metrics TO '" + outputPath + "' (FORMAT PARQUET)";
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+
+    public void close() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+}


### PR DESCRIPTION
This MR introduces a new storage layer for JHeap using DuckDB to handle Parquet/Avro-based metric storage. It simplifies the dependency management by eliminating Hadoop-related dependencies, while maintaining support for Avro schema for data serialization. The new implementation allows for efficient reading and writing of heap memory metrics, leveraging DuckDB's SQL capabilities to query and manage Parquet files with minimal overhead.

close https://github.com/allemas/jheap/issues/1